### PR TITLE
chore: update version to be 0.3.10

### DIFF
--- a/task/bq2bq/optimus-plugin-bq2bq.yaml
+++ b/task/bq2bq/optimus-plugin-bq2bq.yaml
@@ -1,8 +1,8 @@
 name: bq2bq
 description: BigQuery to BigQuery transformation task
 plugintype: task
-pluginversion: 0.3.9 # update this with expected tag before release
-image: docker.io/gotocompany/optimus-task-bq2bq-executor:0.3.9
+pluginversion: 0.3.10 # update this with expected tag before release
+image: docker.io/gotocompany/optimus-task-bq2bq-executor:0.3.10
 entrypoint:
   script: "python3 /opt/bumblebee/main.py"
 questions:


### PR DESCRIPTION
This update was actually part of [this pr](https://github.com/goto/transformers/pull/4). However, if looked closely, it's not being shown in the PR page. But, when being looked through the commit changes from the branch, it is being shown [there](https://github.com/goto/transformers/commit/5170a4379aa143d7102fa010753e81b33b392344).

However, after merging the PR, somehow the changes from this commit is missing from the squashed commit.