### PR TITLE
fix: generated upstreams

### DIFF
--- a/task/bq2bq/main.go
+++ b/task/bq2bq/main.go
@@ -250,7 +250,9 @@ func (b *BQ2BQ) GenerateDependencies(ctx context.Context, request plugin.Generat
 	}
 
 	flattenedUpstreams := upstream.FlattenUpstreams(upstreams)
-	formattedUpstreams := b.formatUpstreams(flattenedUpstreams, func(r upstream.Resource) string {
+	uniqueUpstreams := upstream.UniqueFilterResources(flattenedUpstreams)
+
+	formattedUpstreams := b.formatUpstreams(uniqueUpstreams, func(r upstream.Resource) string {
 		name := fmt.Sprintf("%s:%s.%s", r.Project, r.Dataset, r.Name)
 		return fmt.Sprintf(plugin.DestinationURNFormat, selfTable.Type, name)
 	})

--- a/task/bq2bq/main_test.go
+++ b/task/bq2bq/main_test.go
@@ -293,7 +293,7 @@ Select * from table where ts > "2021-01-16T00:00:00Z"`
 		})
 
 		t.Run("should generate unique dependencies for select statements", func(t *testing.T) {
-			expectedDeps := []string{"bigquery://proj:dataset.table1"}
+			expectedDeps := []string{"bigquery://proj:dataset.table1", "bigquery://proj:dataset.table2"}
 			query := "Select * from proj.dataset.table1 t1 join proj.dataset.table1 t2 on t1.col1 = t2.col1"
 			data := plugin.GenerateDependenciesRequest{
 				Assets: plugin.Assets{
@@ -337,6 +337,29 @@ Select * from table where ts > "2021-01-16T00:00:00Z"`
 			extractor := new(extractorMock)
 			extractor.On("ExtractUpstreams", mock.Anything, query, []upstream.Resource{destination}).
 				Return([]*upstream.Upstream{
+					{
+						Resource: upstream.Resource{
+							Project: "proj",
+							Dataset: "dataset",
+							Name:    "table1",
+						},
+						Upstreams: []*upstream.Upstream{
+							{
+								Resource: upstream.Resource{
+									Project: "proj",
+									Dataset: "dataset",
+									Name:    "table2",
+								},
+							},
+						},
+					},
+					{
+						Resource: upstream.Resource{
+							Project: "proj",
+							Dataset: "dataset",
+							Name:    "table2",
+						},
+					},
 					{
 						Resource: upstream.Resource{
 							Project: "proj",

--- a/task/bq2bq/optimus-plugin-bq2bq.yaml
+++ b/task/bq2bq/optimus-plugin-bq2bq.yaml
@@ -1,8 +1,8 @@
 name: bq2bq
 description: BigQuery to BigQuery transformation task
 plugintype: task
-pluginversion: 0.3.10 # update this with expected tag before release
-image: docker.io/gotocompany/optimus-task-bq2bq-executor:0.3.10
+pluginversion: 0.3.11 # update this with expected tag before release
+image: docker.io/gotocompany/optimus-task-bq2bq-executor:0.3.11
 entrypoint:
   script: "python3 /opt/bumblebee/main.py"
 questions:

--- a/task/bq2bq/upstream/extractor.go
+++ b/task/bq2bq/upstream/extractor.go
@@ -77,23 +77,23 @@ func (e *Extractor) extractNestedNodes(
 	ctx context.Context, schemas []*Schema,
 	ignoredResources, metResource map[Resource]bool,
 ) ([]*Upstream, error) {
-	output := make([]*Upstream, len(schemas))
+	var output []*Upstream
 
-	for i, sch := range schemas {
+	for _, sch := range schemas {
 		if metResource[sch.Resource] {
 			continue
 		}
+		metResource[sch.Resource] = true
 
 		nodes, err := e.getNodes(ctx, sch, ignoredResources, metResource)
 		if err != nil {
 			return nil, err
 		}
 
-		metResource[sch.Resource] = true
-		output[i] = &Upstream{
+		output = append(output, &Upstream{
 			Resource:  sch.Resource,
 			Upstreams: nodes,
-		}
+		})
 	}
 
 	return output, nil

--- a/task/bq2bq/upstream/extractor_test.go
+++ b/task/bq2bq/upstream/extractor_test.go
@@ -70,7 +70,7 @@ func TestExtractor(t *testing.T) {
 				{
 					Message:           "should return filtered upstreams for select statements with ignore statement",
 					QueryRequest:      "Select * from /* @ignoreupstream */ proj.dataset.table1",
-					ExpectedUpstreams: []*upstream.Upstream{},
+					ExpectedUpstreams: nil,
 				},
 				{
 					Message:      "should return filtered upstreams for select statements with ignore statement for view",

--- a/task/bq2bq/upstream/extractor_test.go
+++ b/task/bq2bq/upstream/extractor_test.go
@@ -192,7 +192,7 @@ func TestExtractor(t *testing.T) {
 			assert.NoError(t, actualError)
 		})
 
-		t.Run("should return upstreams even if cyclic is encountered", func(t *testing.T) {
+		t.Run("should return error if circular reference is detected", func(t *testing.T) {
 			client := new(ClientMock)
 			query := new(QueryMock)
 			rowIterator := new(RowIteratorMock)
@@ -230,38 +230,10 @@ func TestExtractor(t *testing.T) {
 			}).Return(nil).Once()
 			rowIterator.On("Next", mock.Anything).Return(iterator.Done).Once()
 
-			expectedUpstreams := []*upstream.Upstream{
-				{
-					Resource: upstream.Resource{
-						Project: "project_test_1",
-						Dataset: "dataset_test_1",
-						Name:    "cyclic_test_1",
-					},
-					Upstreams: []*upstream.Upstream{
-						{
-							Resource: upstream.Resource{
-								Project: "project_test_3",
-								Dataset: "dataset_test_3",
-								Name:    "cyclic_test_3",
-							},
-							Upstreams: []*upstream.Upstream{
-								{
-									Resource: upstream.Resource{
-										Project: "project_test_2",
-										Dataset: "dataset_test_2",
-										Name:    "cyclic_test_2",
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-
 			actualUpstreams, actualError := extractor.ExtractUpstreams(ctx, queryRequest, resourcestoIgnore)
 
-			assert.EqualValues(t, expectedUpstreams, actualUpstreams)
-			assert.NoError(t, actualError)
+			assert.Nil(t, actualUpstreams)
+			assert.ErrorContains(t, actualError, "circular reference is detected")
 		})
 	})
 }

--- a/task/bq2bq/upstream/parser.go
+++ b/task/bq2bq/upstream/parser.go
@@ -15,7 +15,9 @@ var (
 		"|" +
 		"(?i)(?:WITH)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?\\s+(?:AS)" +
 		"|" +
-		"(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?\\s*(?i)(?:AS)?")
+		"(?i)(?:VIEW)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?" +
+		"|" +
+		"(?i)(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`\\s*(?:AS)?")
 
 	queryCommentPatterns = regexp.MustCompile("(--.*)|(((/\\*)+?[\\w\\W]*?(\\*/)+))")
 	helperPattern        = regexp.MustCompile("(\\/\\*\\s*(@[a-zA-Z0-9_-]+)\\s*\\*\\/)")
@@ -41,8 +43,10 @@ func ParseTopLevelUpstreamsFromQuery(query string) []Resource {
 			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 5, 6, 7, 8
 		case "with":
 			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 9, 10, 11, 12
-		default:
+		case "view":
 			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 13, 14, 15, 16
+		default:
+			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 17, 18, 19, 20
 		}
 
 		project := match[projectIdx]
@@ -54,6 +58,10 @@ func ParseTopLevelUpstreamsFromQuery(query string) []Resource {
 		}
 
 		if strings.TrimSpace(match[ignoreUpstreamIdx]) == "@ignoreupstream" {
+			continue
+		}
+
+		if clause == "view" {
 			continue
 		}
 

--- a/task/bq2bq/upstream/parser.go
+++ b/task/bq2bq/upstream/parser.go
@@ -9,7 +9,7 @@ type QueryParser func(query string) []Resource
 
 var (
 	topLevelUpstreamsPattern = regexp.MustCompile("" +
-		"(?i)(?:FROM)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?" +
+		"(?i)(?:FROM)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-\\*?]+)`?" +
 		"|" +
 		"(?i)(?:JOIN)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?" +
 		"|" +

--- a/task/bq2bq/upstream/parser.go
+++ b/task/bq2bq/upstream/parser.go
@@ -13,7 +13,9 @@ var (
 		"|" +
 		"(?i)(?:JOIN)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?" +
 		"|" +
-		"(?i)(?:WITH)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?\\s+(?:AS)")
+		"(?i)(?:WITH)\\s*(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?\\s+(?:AS)" +
+		"|" +
+		"(?:/\\*\\s*([a-zA-Z0-9@_-]*)\\s*\\*/)?\\s+`?([\\w-]+)\\.([\\w-]+)\\.([\\w-]+)`?\\s*(?i)(?:AS)?")
 
 	queryCommentPatterns = regexp.MustCompile("(--.*)|(((/\\*)+?[\\w\\W]*?(\\*/)+))")
 	helperPattern        = regexp.MustCompile("(\\/\\*\\s*(@[a-zA-Z0-9_-]+)\\s*\\*\\/)")
@@ -39,6 +41,8 @@ func ParseTopLevelUpstreamsFromQuery(query string) []Resource {
 			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 5, 6, 7, 8
 		case "with":
 			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 9, 10, 11, 12
+		default:
+			ignoreUpstreamIdx, projectIdx, datasetIdx, nameIdx = 13, 14, 15, 16
 		}
 
 		project := match[projectIdx]

--- a/task/bq2bq/upstream/parser_test.go
+++ b/task/bq2bq/upstream/parser_test.go
@@ -165,6 +165,11 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 						Dataset: "maximum",
 						Name:    "overdrive",
 					},
+					{
+						Project: "project",
+						Dataset: "maximum",
+						Name:    "overdrive",
+					},
 				},
 			},
 			{
@@ -283,6 +288,30 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 						Project: "data-engineering",
 						Dataset: "testing",
 						Name:    "tableABC",
+					},
+				},
+			},
+			{
+				Name: "one or more sources are stated together under from clauses",
+				InputQuery: `
+					select *
+					from
+						pseudo_table1,
+						data-engineering.testing.tableABC,
+						pseudo_table2 as pt2
+						data-engineering.testing.tableDEF as backup_table,
+						/* @ignoreupstream */ data-engineering.testing.tableGHI as ignored_table,
+					`,
+				ExpectedSources: []upstream.Resource{
+					{
+						Project: "data-engineering",
+						Dataset: "testing",
+						Name:    "tableABC",
+					},
+					{
+						Project: "data-engineering",
+						Dataset: "testing",
+						Name:    "tableDEF",
 					},
 				},
 			},

--- a/task/bq2bq/upstream/parser_test.go
+++ b/task/bq2bq/upstream/parser_test.go
@@ -331,6 +331,33 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 					},
 				},
 			},
+			{
+				Name: "one or more sources are from wild-card query",
+				InputQuery: `
+					select *
+					from data-engineering.testing.tableA*
+
+					select *
+					from ` +
+					"`data-engineering.testing.tableB*`" + `
+
+					select *
+					from
+						/*@ignoreupstream*/ data-engineering.testing.tableC*
+					`,
+				ExpectedSources: []upstream.Resource{
+					{
+						Project: "data-engineering",
+						Dataset: "testing",
+						Name:    "tableA*",
+					},
+					{
+						Project: "data-engineering",
+						Dataset: "testing",
+						Name:    "tableB*",
+					},
+				},
+			},
 		}
 
 		for _, test := range testCases {

--- a/task/bq2bq/upstream/parser_test.go
+++ b/task/bq2bq/upstream/parser_test.go
@@ -292,14 +292,30 @@ func TestParseTopLevelUpstreamsFromQuery(t *testing.T) {
 				},
 			},
 			{
+				Name: "ignore `create view` in ddl query",
+				InputQuery: `
+					create view data-engineering.testing.tableABC
+					select *
+					from
+						data-engineering.testing.tableDEF,
+					`,
+				ExpectedSources: []upstream.Resource{
+					{
+						Project: "data-engineering",
+						Dataset: "testing",
+						Name:    "tableDEF",
+					},
+				},
+			},
+			{
 				Name: "one or more sources are stated together under from clauses",
 				InputQuery: `
 					select *
 					from
 						pseudo_table1,
-						data-engineering.testing.tableABC,
+						` + "`data-engineering.testing.tableABC`," + `
 						pseudo_table2 as pt2
-						data-engineering.testing.tableDEF as backup_table,
+						` + "`data-engineering.testing.tableDEF`," + ` as backup_table,
 						/* @ignoreupstream */ data-engineering.testing.tableGHI as ignored_table,
 					`,
 				ExpectedSources: []upstream.Resource{

--- a/task/bq2bq/upstream/schema.go
+++ b/task/bq2bq/upstream/schema.go
@@ -71,7 +71,7 @@ func buildQuery(group *ResourceGroup) string {
 		suffix := "*"
 		if strings.HasSuffix(n, suffix) {
 			prefix, _ := strings.CutSuffix(n, suffix)
-			prefixQuery := fmt.Sprintf("or STARTS_WITH(%s, %s)", n, prefix)
+			prefixQuery := fmt.Sprintf("STARTS_WITH(table_name, '%s')", prefix)
 			prefixQueries = append(prefixQueries, prefixQuery)
 		} else {
 			nameQuery := fmt.Sprintf("'%s'", n)
@@ -79,10 +79,21 @@ func buildQuery(group *ResourceGroup) string {
 		}
 	}
 
+	names := strings.Join(nameQueries, ", ")
+	prefixes := strings.Join(prefixQueries, " or\n")
+
+	var whereClause string
+	if len(nameQueries) > 0 && len(prefixQueries) > 0 {
+		whereClause = fmt.Sprintf("WHERE table_name in (%s) or %s", names, prefixes)
+	} else if len(nameQueries) > 0 {
+		whereClause = fmt.Sprintf("WHERE table_name in (%s)", names)
+	} else if len(prefixQueries) > 0 {
+		whereClause = fmt.Sprintf("WHERE %s", prefixes)
+	}
+
 	return "SELECT table_catalog, table_schema, table_name, table_type, ddl\n" +
 		fmt.Sprintf("FROM `%s.%s.INFORMATION_SCHEMA.TABLES`\n", group.Project, group.Dataset) +
-		fmt.Sprintf("WHERE table_name in (%s)\n", strings.Join(nameQueries, ", ")) +
-		strings.Join(prefixQueries, "\n")
+		whereClause
 }
 
 func convertToSchema(values []bigquery.Value) (*Schema, error) {

--- a/task/bq2bq/upstream/schema.go
+++ b/task/bq2bq/upstream/schema.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+const wildCardSuffix = "*"
+
 type SchemaType string
 
 const (
@@ -68,9 +70,8 @@ func ReadSchemasUnderGroup(ctx context.Context, client bqiface.Client, group *Re
 func buildQuery(group *ResourceGroup) string {
 	var nameQueries, prefixQueries []string
 	for _, n := range group.Names {
-		suffix := "*"
-		if strings.HasSuffix(n, suffix) {
-			prefix, _ := strings.CutSuffix(n, suffix)
+		if strings.HasSuffix(n, wildCardSuffix) {
+			prefix, _ := strings.CutSuffix(n, wildCardSuffix)
 			prefixQuery := fmt.Sprintf("STARTS_WITH(table_name, '%s')", prefix)
 			prefixQueries = append(prefixQueries, prefixQuery)
 		} else {

--- a/task/bq2bq/upstream/upstream.go
+++ b/task/bq2bq/upstream/upstream.go
@@ -8,6 +8,10 @@ type Upstream struct {
 func FlattenUpstreams(upstreams []*Upstream) []Resource {
 	var output []Resource
 	for _, u := range upstreams {
+		if u == nil {
+			continue
+		}
+
 		output = append(output, u.Resource)
 
 		nested := FlattenUpstreams(u.Upstreams)

--- a/task/bq2bq/upstream/upstream_test.go
+++ b/task/bq2bq/upstream/upstream_test.go
@@ -39,6 +39,7 @@ func TestFlattenUpstreams(t *testing.T) {
 							Name:    "name_test_4",
 						},
 					},
+					nil,
 				},
 			},
 		}


### PR DESCRIPTION
This is to address issues when generating upstreams, specifically:

* duplicate upstream after flattening
* add limited extractor reusability to reduce the number of query being hit
* address circular (cyclic) dependency
* address wild-card query
* multiple specified source specified under `FROM` clause, such as:

```sql
...
select *
from table, `project.dataset.table`
```