### PR TITLE
fix: update golang version to 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: Run GoReleaser for branch [Main]
         uses: goreleaser/goreleaser-action@v2.6.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/task/bq2bq/go.mod
+++ b/task/bq2bq/go.mod
@@ -1,6 +1,6 @@
 module github.com/goto/transformers/task/bq2bq
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/bigquery v1.44.0


### PR DESCRIPTION
This is to address issue related to Github action after the previous commit. The issue is, one function being used in that commit, which is `CutSuffix`, is only supported in go 1.20. However, the action being used is still go 1.18.

Reference:
* https://pkg.go.dev/strings#CutSuffix