### PR TITLE
fix: goreleaser flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: -f .goreleaser.yml --snapshot --rm-dist
+          args: -f .goreleaser.yml --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: -f .goreleaser.yml --rm-dist
+          args: -f .goreleaser.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}


### PR DESCRIPTION
to comply with latest goreleaser version [ref](https://github.com/goto/transformers/blob/36729e6428360cced641753a72ec6555427a3301/.github/workflows/release.yml#L31)